### PR TITLE
Add convenience function `to_pyvista`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lnmmeshio"
-version = "5.3.2"
+version = "5.4.0"
 authors = [
   { name="Amadeus Gebauer", email="amadeus.gebauer@tum.de" },
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pre-commit==3.0.2
 parameterized==0.8.1
 coverage==5.2.1
 pdoc==12.3.1
+pyvista==0.44.1

--- a/src/lnmmeshio/__init__.py
+++ b/src/lnmmeshio/__init__.py
@@ -11,15 +11,7 @@ from meshio import Mesh
 from meshio import read as _meshioread
 from meshio import write as _meshiowrite
 
-from . import (
-    element,
-    ensightio,
-    ioutils,
-    meshio_to_discretization,
-    mimics_stlio,
-    node,
-    nodeset,
-)
+from . import element, ensightio, ioutils, mimics_stlio, node, nodeset
 from .discretization import Discretization
 from .element.element import (
     Element,
@@ -245,8 +237,27 @@ def read_sections(filename: str) -> Dict[str, List[str]]:
 
 
 def from_mesh(mesh: Mesh) -> Discretization:
+    """
+    Converts a meshio.Mesh to a discretization
+    """
+    from . import meshio_to_discretization
+
     return meshio_to_discretization.mesh2Discretization(mesh)
 
 
 def to_mesh(mesh: Discretization) -> Mesh:
+    """
+    Converts a discretization to a meshio.Mesh
+    """
+    from . import meshio_to_discretization
+
     return meshio_to_discretization.discretization2mesh(mesh)
+
+
+def to_pyvista(dis: Discretization):
+    """
+    Converts a discretization to a pyvista unstructured grid
+    """
+    import pyvista
+
+    return pyvista.from_meshio(to_mesh(dis))

--- a/src/lnmmeshio/meshio_to_discretization.py
+++ b/src/lnmmeshio/meshio_to_discretization.py
@@ -1,6 +1,4 @@
 #
-# Maintainer: Amadeus Gebauer
-#
 # This is the interface between the meshio package and our Discretization description
 # May not work perfectly
 #

--- a/test_lnmmeshio/test_to_pyvista.py
+++ b/test_lnmmeshio/test_to_pyvista.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+from typing import List
+
+import lnmmeshio
+import numpy as np
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestPyvista(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_to_pyvista(self):
+        dis = lnmmeshio.read(os.path.join(script_dir, "data", "dummy2.dat"))
+
+        # convert to pyvista
+        mesh = lnmmeshio.to_pyvista(dis)
+
+        np.testing.assert_equal(mesh.cells, np.array([4, 0, 1, 2, 3]))
+        np.testing.assert_equal(
+            mesh.points,
+            np.array(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+            ),
+        )


### PR DESCRIPTION
Add new convenience function to convert a discretization directly to a pyvista mesh.

```
pyvista_mesh = lnmmeshio.to_pyvista(dis)
```

Additionally, mesh_to_discretization is hided to the outside and only the functions `lnmmeshio.from_mesh()` and `lnmmeshio.to_mesh()` are exposed.