### PR TITLE
Fix HEX27 node ordering + Add cell group id to element data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lnmmeshio"
-version = "5.6.1"
+version = "5.6.2"
 authors = [
   { name="Amadeus Gebauer", email="amadeus.gebauer@tum.de" },
 ]

--- a/src/lnmmeshio/meshio_to_discretization.py
+++ b/src/lnmmeshio/meshio_to_discretization.py
@@ -147,22 +147,22 @@ ele_node_order_vtk2baci = {
         9,
         10,
         11,
-        16,
-        17,
-        18,
-        19,
         12,
         13,
         14,
         15,
-        20,
+        16,
+        17,
+        18,
+        19,
         21,
-        22,
-        23,
-        24,
         25,
+        24,
         26,
-    ],  # verify ?
+        23,
+        22,
+        20,
+    ],
     "WEDGE6": list(range(0, 6)),
     "QUAD4": list(range(0, 4)),
     "QUAD9": list(range(0, 9)),
@@ -242,6 +242,9 @@ def mesh2Discretization(mesh: meshio.Mesh) -> Discretization:
                 # extract cell data
                 for key, data in mesh.cell_data.items():
                     ele.data[key] = data[cellgroupid][cellid]
+
+                # explicitly append the cell group id (block id) to the cell data
+                ele.data["GROUP_ID"] = cellgroupid
 
                 # create surface-nodesets
                 if maxdim == 2 and len(mesh.cell_data) > 0:


### PR DESCRIPTION
Explicitly added the cell group id to the element data. 
This helps in delimiting the various regions of the computational domain.

Fixed the HEX27 node ordering when converting from `meshio` to `Discretization` to match the current ordering in 4C.
This was previously incorrect (see screenshot below: left column: node ordering generated by pre_exodus, middle column: ordering with the current state of the package, right column: fixed HEX27 ordering).

![image](https://github.com/user-attachments/assets/429c0f63-f9f4-45ac-9005-b46d7cc756ef)


