### PR TITLE
Relax version requirement of loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lnmmeshio"
-version = "5.6.2"
+version = "5.6.3"
 authors = [
   { name="Amadeus Gebauer", email="amadeus.gebauer@tum.de" },
 ]
@@ -20,7 +20,7 @@ dependencies = [
     "numpy>=1.22.1",
     "python-utils>=2.3.0",
     "meshio>=5.3.5, <6",
-    "loguru==0.7.2",
+    "loguru>=0.7.2",
     "tqdm==4.66.5",
     "PyYAML>=6.0.0, <7",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.22.0
 progress==1.5
 meshio==5.3.5
-loguru==0.7.2
+loguru>=0.7.2
 tqdm==4.66.5


### PR DESCRIPTION
As discussed, the version requirement of the dependency loguru is relaxed from ==0.7.2, i.e., an exact patch version to be larger than that version (>=0.7.2).

The lnmmeshio patch version is incremented as well.